### PR TITLE
Insert+Erase Implementation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,6 +3,7 @@
   - https://github.com/leanprover/lean4/blob/master/src/Lean/Data/RBMap.lean
   - https://www.cs.tufts.edu/comp/150FP/archive/chris-okasaki/redblack99.pdf
   - https://www.cs.cmu.edu/~rwh/students/okasaki.pdf
+  - https://www.khoury.northeastern.edu/~camoy/pub/red-black-tree.pdf
   Functions:
   - `RBSet.Raw`
   - `Membership`

--- a/Filrb/Internal/Invariants.lean
+++ b/Filrb/Internal/Invariants.lean
@@ -27,14 +27,6 @@ theorem bst_insert_of_bst (x : α) (t : Raw α) (h : BST t) : BST (t.insert x) :
 theorem bst_erase_of_bst (x : α) (t : Raw α) (h : BST t) : BST (t.erase x) := sorry
 
 /--
-Fetch the color of the root of `t`.
--/
-def rootColor (t : Raw α) : Color :=
-  match t with
-  | .nil => .black
-  | .node _ _ c _ => c
-
-/--
 The child invariant for red black trees: Red nodes must have black children.
 -/
 inductive ChildInv : Raw α → Prop where

--- a/Filrb/Internal/Raw.lean
+++ b/Filrb/Internal/Raw.lean
@@ -95,8 +95,8 @@ example : inorder2 t xs = inorder t ++ xs := by
 Transform a tree into a graphviz compatible format.
 -/
 def toGraphviz {α : Type} [ToString α] (t : Raw α) : String :=
-  let ⟨graph, _⟩ := go "" 1 t
-  "Digraph tree {\n  node [style=filled];" ++ graph ++ "\n}"
+  let ⟨graph, _⟩ := go "Digraph tree {\n  node [style=filled];" 1 t
+  graph ++ "\n}"
 where
   go {α : Type} [ToString α] (acc : String) (idx : Nat) (t : Raw α) : String × Nat :=
     match t  with
@@ -104,10 +104,10 @@ where
       ⟨acc ++ s!"\n  {idx} [shape=point];", idx⟩
     | Raw.node l x c r =>
       let node := s!"\n  {idx} [label=\"{x}\",{colorEdgeStyle c}, shape=circle];"
-      let ⟨lnode, lidx⟩ := go "" (idx+1) l
-      let ⟨rnode, ridx⟩ := go "" (lidx+1) r
+      let ⟨lnode, lidx⟩ := go (acc ++ node) (idx+1) l
+      let ⟨rnode, ridx⟩ := go lnode (lidx+1) r
       let edges := s!"\n  {idx} -> {idx+1} [label=\"l\"];\n  {idx} -> {lidx+1} [label=\"r\"];"
-      ⟨acc ++ node ++ lnode ++ rnode ++ edges, ridx⟩
+      ⟨rnode ++ edges, ridx⟩
   colorEdgeStyle : Color → String
     | .red => " color=red"
     | .black => " color=grey"


### PR DESCRIPTION
Mostly a copy from Nipkow. The only difference (which is copied from the lean std library) is about how to handle erasure of a node. Nipkow introduces `split_min` to construct the replacement tree of the left and right subtree after finding the node, which is to be erased. It computes the minimal value and then reconstructs through the balance functions a balanced tree. Stdlib just appends the trees by enumerating the critical pairs as far as I can tell
